### PR TITLE
Molecule tests refactory

### DIFF
--- a/.dev_requirements.txt
+++ b/.dev_requirements.txt
@@ -2,5 +2,6 @@ ansible
 ansible-lint
 yamllint
 molecule
-molecule-docker
-molecule-podman
+molecule-plugins
+molecule-plugins[docker]
+molecule-plugins[podman]

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -17,6 +17,6 @@ jobs:
         run: pip3 install -r .dev_requirements.txt
 
       - name: test playbook
-        run: molecule test --driver-name docker
+        run: molecule test
         env:
           PY_COLORS: '1'

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,7 +2,7 @@
 - name: Converge
   hosts: all
   vars:
-    opencast_version_major: 12
+    opencast_version_major: 17
     opencast_repository_enabled_release: true
     opencast_repository_enabled_testing: true
   tasks:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,41 +1,35 @@
 ---
 dependency:
   name: galaxy
+  enabled: false
 driver:
-  name: podman
+  name: containers
 platforms:
-  - name: oc_repository_centos_7
-    image: docker.io/library/centos:7
-    pre_build_image: true
-  - name: oc_repository_centos_8
-    image: quay.io/centos/centos:stream8
-    pre_build_image: false
-    command: /sbin/init
-    tmpfs:
-      - /run
-      - /tmp
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: oc_repository_centos_9
     image: quay.io/centos/centos:stream9
     pre_build_image: false
     command: /sbin/init
     tmpfs:
-      - /run
-      - /tmp
+      "/run": "rw,noexec,nosuid,nodev"
+      "/tmp": "exec"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: oc_repository_debian
-    image: docker.io/library/python:bullseye
-    pre_build_image: true
+    image: docker.io/debian:stable
+    pre_build_image: false
+    command: /sbin/init
+    tmpfs:
+      "/run": "rw,noexec,nosuid,nodev"
+      "/tmp": "exec"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: oc_repository_ubuntu
     image: docker.io/ubuntu:latest
     pre_build_image: false
-    privileged: true
     command: /sbin/init
     tmpfs:
-      - /run
-      - /tmp
+      "/run": "rw,noexec,nosuid,nodev"
+      "/tmp": "exec"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 lint: |

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -3,7 +3,7 @@
   hosts: all
   gather_facts: true
   vars:
-    opencast_version_major: 12
+    opencast_version_major: 17
   tasks:
     - name: Test if opencast is available
       ansible.builtin.package:


### PR DESCRIPTION
This customizations are made:
- Dropped support for EL8 and EL9 due to EOL
- Dropped support for Debian Bullseye due to EOL
- Debian stable support added
- Replaced python image with debian, due to inconsistent Python versions
- Changed molecule driver to containers
  - works with Podman and Docker